### PR TITLE
Capture the two window handles for use

### DIFF
--- a/pages/webdriver/base.py
+++ b/pages/webdriver/base.py
@@ -12,8 +12,13 @@ class Base(object):
     def __init__(self, selenium, timeout=60):
         self.selenium = selenium
         self.timeout = timeout
+        self._main_window_handle = self.selenium.current_window_handle
+
         if selenium.title != self._page_title:
             for handle in selenium.window_handles:
                 selenium.switch_to_window(handle)
                 if selenium.title == self._page_title:
                     break
+
+    def switch_to_main_window(self):
+        self.selenium.switch_to_window(self._main_window_handle)

--- a/pages/webdriver/sign_in.py
+++ b/pages/webdriver/sign_in.py
@@ -55,7 +55,7 @@ class SignIn(Base):
     def click_sign_in(self):
         """Clicks the 'Sign In' button."""
         self.selenium.find_element(*self._sign_in_locator).click()
-        self.selenium.switch_to_window('')
+        self.switch_to_main_window()
 
     def sign_in(self, email, password):
         """Signs in using the specified email address and password."""


### PR DESCRIPTION
Capture the two window handles while looping through them to find the browserID window.

Make the signin use window handle rather than the zls window name. This is required because OperaDriver overwrites the window.name and thus it can not be targeted reliably.
