### PR TITLE
Update branding and find popup loop

### DIFF
--- a/pages/webdriver/base.py
+++ b/pages/webdriver/base.py
@@ -7,7 +7,7 @@
 
 class Base(object):
 
-    _page_title = 'BrowserID'
+    _page_title = 'Mozilla Persona'
 
     def __init__(self, selenium, timeout=60):
         self.selenium = selenium

--- a/pages/webdriver/sign_in.py
+++ b/pages/webdriver/sign_in.py
@@ -28,6 +28,8 @@ class SignIn(Base):
                 self.selenium.switch_to_window(handle)
                 if self.selenium.title == self._page_title:
                     break
+            else:
+                raise Exception('Popup has not loaded')
 
         if expect == 'new':
             WebDriverWait(self.selenium, self.timeout).until(


### PR DESCRIPTION
Change page title branding to "Personas"

Add else clause to the loop to fail test if the window cannot be found. Previously when the loop was expended without finding the window the test would continue. Depending on the browser type it may be the currently selected window or it may not so the test was flaky. Now it will certainly fail.
