### PR TITLE
Add 'add new email' for multiple-email logins.

### DIFF
--- a/pages/webdriver/sign_in.py
+++ b/pages/webdriver/sign_in.py
@@ -11,6 +11,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import time
 
+
 class SignIn(Base):
 
     _this_is_not_me_locator = (By.ID, 'thisIsNotMe')
@@ -105,9 +106,6 @@ class SignIn(Base):
         """ Select email from the returning user's multiple emails """
         checkbox = self.selenium.find_element(By.CSS_SELECTOR, "input[value='%s']" % value)
         checkbox.click()
-
-    def check_email_at_address(self):
-        return self.selenium.find_element(*self._check_email_at_locator).text
 
     @property
     def password(self):


### PR DESCRIPTION
Add locators and methods to enable the user to add a second email address to an existing one.

Before you explode at the sight of `sleep(2)` , the existing wait is sufficient for logging in a returning user but it was insufficient for clicking 'add another email' or 'this is not me'. I tried dozens of variations of waits but could not for the life of me get this right. It would always simple perform the click but the popup would not change.

Feel free to attempt to find a cleaner wait but I could not :(

@AlinT has offered to write the tests for it too :)
