### PR TITLE
Encapsulate all 123done.org locators into tests/base.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,9 +29,10 @@ def pytest_addoption(parser):
 
 
 def pytest_funcarg__mozwebqa(request):
+    persona_login_button_locator_css = 'button.btn-persona'
     mozwebqa = request.getfuncargvalue('mozwebqa')
     mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
     WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-        lambda s: s.find_element_by_css_selector('button.btn-persona').is_displayed())
-    mozwebqa.selenium.find_element_by_css_selector('button.btn-persona').click()
+        lambda s: s.find_element_by_css_selector(persona_login_button_locator_css).is_displayed())
+    mozwebqa.selenium.find_element_by_css_selector(persona_login_button_locator_css).click()
     return mozwebqa

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,6 +7,7 @@
 import re
 
 import requests
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
 from .. import BrowserID
@@ -15,6 +16,10 @@ import restmail
 
 
 class BaseTest(object):
+
+    _persona_login_button_locator = (By.CSS_SELECTOR, 'button.btn-persona')
+    _persona_logged_in_indicator_locator = (By.ID, 'loggedin')
+    _persona_log_out_link_locator = (By.CSS_SELECTOR, '#loggedin a')
 
     def browserid_url(self, base_url):
         response = requests.get('%s/' % base_url, verify=False)
@@ -26,10 +31,10 @@ class BaseTest(object):
 
     def log_out(self, selenium, timeout):
         WebDriverWait(selenium, timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
-        selenium.find_element_by_css_selector('#loggedin a').click()
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
+        selenium.find_element(*self._persona_log_out_link_locator).click()
         WebDriverWait(selenium, timeout).until(
-            lambda s: s.find_element_by_css_selector('button.btn-persona').is_displayed())
+            lambda s: s.find_element(*self._persona_login_button_locator).is_displayed())
 
     def create_verified_user(self, selenium, timeout):
         user = MockUser()

--- a/tests/check_add_email.py
+++ b/tests/check_add_email.py
@@ -23,7 +23,7 @@ class TestAddEmail(BaseTest):
 
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
         self.log_out(mozwebqa.selenium, mozwebqa.timeout)
-        mozwebqa.selenium.find_element_by_css_selector('button.btn-persona').click()
+        mozwebqa.selenium.find_element(*self._persona_login_button_locator).click()
 
         from .. pages.sign_in import SignIn
         signin = SignIn(mozwebqa.selenium, mozwebqa.timeout, expect='returning')
@@ -49,7 +49,7 @@ class TestAddEmail(BaseTest):
 
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
         self.log_out(mozwebqa.selenium, mozwebqa.timeout)
-        mozwebqa.selenium.find_element_by_css_selector('button.btn-persona').click()
+        mozwebqa.selenium.find_element(*self._persona_login_button_locator).click()
 
         signin = SignIn(mozwebqa.selenium, mozwebqa.timeout, expect='returning')
         assert user.additional_emails[0] in signin.emails

--- a/tests/check_reset_password.py
+++ b/tests/check_reset_password.py
@@ -21,7 +21,7 @@ class TestResetPassword(BaseTest):
         user = self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
         self.log_out(mozwebqa.selenium, mozwebqa.timeout)
-        mozwebqa.selenium.find_element_by_css_selector('button.btn-persona').click()
+        mozwebqa.selenium.find_element(*self._persona_login_button_locator).click()
 
         from .. pages.sign_in import SignIn
         signin = SignIn(mozwebqa.selenium, mozwebqa.timeout, expect='returning')

--- a/tests/check_sign_in.py
+++ b/tests/check_sign_in.py
@@ -22,7 +22,7 @@ class TestSignIn(BaseTest):
         browser_id.sign_in(mozwebqa.email, mozwebqa.password)
 
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
 
     def test_sign_in(self, mozwebqa):
         from .. pages.sign_in import SignIn
@@ -35,7 +35,7 @@ class TestSignIn(BaseTest):
         signin.click_sign_in()
 
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
 
     @pytest.mark.travis
     def test_sign_in_new_user_helper(self, mozwebqa):
@@ -71,23 +71,23 @@ class TestSignIn(BaseTest):
         self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
 
     def test_sign_in_is_this_your_computer(self, mozwebqa):
         browser_id = BrowserID(mozwebqa.selenium, mozwebqa.timeout)
         browser_id.sign_in(mozwebqa.email, mozwebqa.password)
 
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
         login_time = time.time()
 
         self.log_out(mozwebqa.selenium, mozwebqa.timeout)
 
         while time.time() < (login_time + 60):
             time.sleep(15)
-            mozwebqa.selenium.find_element_by_css_selector('button.btn-persona')
+            mozwebqa.selenium.find_element(*self._persona_login_button_locator)
 
-        mozwebqa.selenium.find_element_by_css_selector('button.btn-persona').click()
+        mozwebqa.selenium.find_element(*self._persona_login_button_locator).click()
 
         from .. pages.sign_in import SignIn
         signin = SignIn(mozwebqa.selenium, mozwebqa.timeout, expect='returning')
@@ -95,4 +95,4 @@ class TestSignIn(BaseTest):
         signin.click_i_trust_this_computer()
 
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
-            lambda s: s.find_element_by_id('loggedin').is_displayed())
+            lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())


### PR DESCRIPTION
While making changes to the bidpom tests due to a change to 123done.org, I noticed that locators for the app were hardcoded all over the place. We should follow best practices and put them in one place.

I could have created a page object for the 123done.org home page, but I didn't want to mix that (which is only needed for the tests) with the actual bidpom page objects, which are used by other suites. I could have put the page object somewhere else, e.g., /tests/pages, but it seemed simpler to just put the locators into tests/base.py.

Feedback is welcomed.

Pinging @davehunt on this as he asked me to do so in irc earlier today when this came up.
