### PR TITLE
Update assertions due to change in text in email

### DIFF
--- a/tests/check_add_email.py
+++ b/tests/check_add_email.py
@@ -36,7 +36,7 @@ class TestAddEmail(BaseTest):
 
         mail = restmail.get_mail(user.additional_emails[0],
                                  timeout=mozwebqa.timeout)
-        assert 'Click this confirmation link to sign in' in mail[0]['text']
+        assert 'Click this link to confirm access' in mail[0]['text']
         confirm_url = re.search(
             BrowserID.CONFIRM_URL_REGEX, mail[0]['text']).group(0)
 

--- a/tests/check_sign_in.py
+++ b/tests/check_sign_in.py
@@ -45,7 +45,7 @@ class TestSignIn(BaseTest):
         print 'signing in as %s' % user.primary_email
         signin.sign_in_new_user(user.primary_email, 'password')
         mail = restmail.get_mail(user.primary_email, timeout=mozwebqa.timeout)
-        assert 'Click this confirmation link to sign in' in mail[0]['text']
+        assert 'Click this link to confirm access' in mail[0]['text']
 
     @pytest.mark.travis
     def test_sign_in_new_user(self, mozwebqa):
@@ -64,7 +64,7 @@ class TestSignIn(BaseTest):
         signin.close_window()
         signin.switch_to_main_window()
         mail = restmail.get_mail(user.primary_email, timeout=mozwebqa.timeout)
-        assert 'Click this confirmation link to sign in' in mail[0]['text']
+        assert 'Click this link to confirm access' in mail[0]['text']
 
     @pytest.mark.travis
     def test_sign_in_returning_user(self, mozwebqa):


### PR DESCRIPTION
This addresses the three failures as seen at [1]. seanmonstar in #identity confirmed that the text of the email has changed.

[1] http://qa-selenium.mv.mozilla.com:8080/view/BIDPOM/job/bidpom.stage/285/
