### PR TITLE
Introduce fuzzy logic for email checking to make tests less brittle

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -52,3 +52,7 @@ class BaseTest(object):
                                                      expect='success')
         assert user['primary_email'] in complete_registration.user_loggedin
         return user
+
+    def email_appears_valid(self, email_text):
+        assert 'Click' in email_text and 'link' in email_text, \
+            'The strings "Click" and "link" were not found in %s' % email_text

--- a/tests/check_add_email.py
+++ b/tests/check_add_email.py
@@ -36,7 +36,10 @@ class TestAddEmail(BaseTest):
 
         mail = restmail.get_mail(user.additional_emails[0],
                                  timeout=mozwebqa.timeout)
-        assert 'Click this link to confirm access' in mail[0]['text']
+
+        # Check that the email appears to be valid
+        self.email_appears_valid(mail[0]['text'])
+
         confirm_url = re.search(
             BrowserID.CONFIRM_URL_REGEX, mail[0]['text']).group(0)
 

--- a/tests/check_sign_in.py
+++ b/tests/check_sign_in.py
@@ -45,7 +45,9 @@ class TestSignIn(BaseTest):
         print 'signing in as %s' % user.primary_email
         signin.sign_in_new_user(user.primary_email, 'password')
         mail = restmail.get_mail(user.primary_email, timeout=mozwebqa.timeout)
-        assert 'Click this link to confirm access' in mail[0]['text']
+
+        # Check that the email appears to be valid
+        self.email_appears_valid(mail[0]['text'])
 
     @pytest.mark.travis
     def test_sign_in_new_user(self, mozwebqa):
@@ -64,7 +66,9 @@ class TestSignIn(BaseTest):
         signin.close_window()
         signin.switch_to_main_window()
         mail = restmail.get_mail(user.primary_email, timeout=mozwebqa.timeout)
-        assert 'Click this link to confirm access' in mail[0]['text']
+
+        # Check that the email appears to be valid
+        self.email_appears_valid(mail[0]['text'])
 
     @pytest.mark.travis
     def test_sign_in_returning_user(self, mozwebqa):


### PR DESCRIPTION
The email text has changed twice, and I don't think we need to be very specific with what we check, so I made this change to hopefully make the tests less prone to breakage when they tweak the email text.

This addresses 3 failures as seen at http://qa-selenium.mv.mozilla.com:8080/view/BIDPOM/job/bidpom.stage/335/testReport/
