### PR TITLE
Added a wait for the loading spinner to disappear when tapping next afte...

### DIFF
--- a/browserid/pages/sign_in.py
+++ b/browserid/pages/sign_in.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 class SignIn(Base):
 
     _form_completing_loading_locator = (By.CSS_SELECTOR, '.form.completing.loading')
+    _checking_email_provider_loading_locator = (By.CSS_SELECTOR, '#load .loadingSpinner')
     _this_is_not_me_locator = (By.CSS_SELECTOR, '.isDesktop.thisIsNotMe')
     _signed_in_email_locator = (By.CSS_SELECTOR, 'label[for=email_0]')
     _emails_locator = (By.CSS_SELECTOR, 'label[for^=email_]')
@@ -170,6 +171,10 @@ class SignIn(Base):
             self.selenium.find_element(*self._desktop_next_locator).click()
         else:
             self.selenium.find_element(*self._mobile_next_locator).click()
+
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: not s.find_element(
+                *self._checking_email_provider_loading_locator).is_displayed())
 
         if expect == 'password':
             WebDriverWait(self.selenium, self.timeout).until(


### PR DESCRIPTION
...r you type the email.

It looks like some tests are failing because it tries to click the sign in button while the spinner is still displayed.
The spinner is displayed when checking the email provider.
