### PR TITLE
Xfail failing tests with reason Bug 1105256 - Confirmation email is not ...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest-mozwebqa==1.1.1
+pytest-mozwebqa
 requests==0.13.3

--- a/tests/check_add_email.py
+++ b/tests/check_add_email.py
@@ -17,6 +17,7 @@ import restmail
 class TestAddEmail(BaseTest):
 
     @pytest.mark.travis
+    @pytest.mark.xfail(reason="Bug 1105256 - Confirmation email is not received from http://beta.123done.org/")
     def test_add_email(self, mozwebqa):
         user = self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         user.additional_emails.append('%s_1@restmail.net' % user.id)

--- a/tests/check_reset_password.py
+++ b/tests/check_reset_password.py
@@ -17,6 +17,7 @@ import restmail
 class TestResetPassword(BaseTest):
 
     @pytest.mark.travis
+    @pytest.mark.xfail(reason="Bug 1105256 - Confirmation email is not received from http://beta.123done.org/")
     def test_reset_password(self, mozwebqa):
         user = self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)

--- a/tests/check_sign_in.py
+++ b/tests/check_sign_in.py
@@ -38,6 +38,7 @@ class TestSignIn(BaseTest):
             lambda s: s.find_element(*self._persona_logged_in_indicator_locator).is_displayed())
 
     @pytest.mark.travis
+    @pytest.mark.xfail(reason="Bug 1105256 - Confirmation email is not received from http://beta.123done.org/")
     def test_sign_in_new_user_helper(self, mozwebqa):
         user = MockUser()
         from browserid.pages.sign_in import SignIn
@@ -50,6 +51,7 @@ class TestSignIn(BaseTest):
         self.email_appears_valid(mail[0]['text'])
 
     @pytest.mark.travis
+    @pytest.mark.xfail(reason="Bug 1105256 - Confirmation email is not received from http://beta.123done.org/")
     def test_sign_in_new_user(self, mozwebqa):
         user = MockUser()
         from browserid.pages.sign_in import SignIn
@@ -71,6 +73,7 @@ class TestSignIn(BaseTest):
         self.email_appears_valid(mail[0]['text'])
 
     @pytest.mark.travis
+    @pytest.mark.xfail(reason="Bug 1105256 - Confirmation email is not received from http://beta.123done.org/")
     def test_sign_in_returning_user(self, mozwebqa):
         self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         mozwebqa.selenium.get('%s/' % mozwebqa.base_url)


### PR DESCRIPTION
...received from http://beta.123done.org/

https://bugzilla.mozilla.org/show_bug.cgi?id=1105256
