### PR TITLE
Switch Travis-CI to just flake8 checking (#90)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,4 @@
-before_script:
-  - sh -e /etc/init.d/xvfb start
-
 language: python
-python:
-  - 2.6
-  - 2.7
-
-script: py.test --baseurl=http://beta.123done.org --driver=firefox --webqatimeout=90 -m travis tests
-
-env:
-  - DISPLAY=':99.0'
-
-notifications:
-  email:
-    - webqa-ci@mozilla.org
-  irc:
-    - "irc.mozilla.org#automation"
-    - "irc.mozilla.org#identity"
+python: 2.7
+install: "pip install flake8"
+script: "flake8 ."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
-python_files=check_*.py
+[flake8]
+ignore=E501


### PR DESCRIPTION
This tweak fixes issue #90, switching Travis-CI to use only flake8 checking.

Hopefully I've interpreted Dave's excellent instructions correctly :)

Adding @davehunt for review and @stephendonner for visibility.