### PR TITLE
Use HTTP for restmail due to certificate issues

### DIFF
--- a/tests/restmail.py
+++ b/tests/restmail.py
@@ -15,7 +15,7 @@ def get_mail(username, message_count=1, timeout=60):
     end_time = time.time() + timeout
     while(True):
         response = requests.get(
-            'https://restmail.net/mail/%s' % username,
+            'http://restmail.net/mail/%s' % username,
             verify=False)
         restmail = json.loads(response.content)
         if len(restmail) == message_count:


### PR DESCRIPTION
See [bug 1197023](https://bugzilla.mozilla.org/show_bug.cgi?id=1197023) and [bug 1197129](https://bugzilla.mozilla.org/show_bug.cgi?id=1197129) for details. Pinging @m8ttyB for review.