### PR TITLE
Improve wait for page to be ready when returning user

### DIFF
--- a/browserid/pages/sign_in.py
+++ b/browserid/pages/sign_in.py
@@ -55,9 +55,12 @@ class SignIn(Base):
         WebDriverWait(self.selenium, self.timeout).until(self._is_page_ready)
 
     def _is_page_ready(self, s):
-        is_page_ready = s.find_element(*self._email_locator).is_displayed() or \
-            s.find_element(*self._sign_in_returning_user_locator).is_displayed()
-        return is_page_ready
+        if s.find_element(*self._email_locator).is_displayed():
+            return True
+        else:
+            body = self.selenium.find_element(By.TAG_NAME, 'body')
+            sign_in = s.find_element(*self._sign_in_returning_user_locator)
+            return sign_in.is_displayed() and 'submit_disabled' not in body.get_attribute('class')
 
     @property
     def is_initial_sign_in(self):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (OSError, IOError):
     description = ''
 
 setup(name='browserid',
-      version='1.3',
+      version='1.4',
       description="Mozilla BrowserID (Persona) Page Object Model",
       long_description=description,
       classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
I noticed an intermittent when clicking the 'sign in' button on the returning user page that was affecting Affiliates. It seems more prevalent in Selenium 2.48 but it's not related to clicking on the wrong element - we're clicking before the element is ready for interaction. Some investigation showed a `submit_disabled` class on the `body` element in the cases where we failed.

Pinging @bobsilverberg for review.