### PR TITLE
Update pytest to 2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==2.9.0
+pytest==2.9.1
 pytest-selenium
 pytest-xdist==1.14
 requests==2.9.1


### PR DESCRIPTION
Passes for me, and here's an ad-hoc run: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/bidpom.adhoc/38/console

Output: https://pastebin.mozilla.org/8864561